### PR TITLE
feat: support filter commit scope

### DIFF
--- a/main.go
+++ b/main.go
@@ -241,7 +241,7 @@ func (a *action) generateMarkdownChangelog(output, version string, commits []con
 	}
 
 	markdownGenerator := changelog.NewMarkdownGenerator(oldData, version, time.Now())
-	newData := markdownGenerator.Generate(commits)
+	newData := markdownGenerator.Generate(commits, a.flags.scopes)
 
 	if err := os.WriteFile(output, []byte(newData), 0o644); err != nil {
 		return fmt.Errorf("failed to write file %s: %w", output, err)

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ type action struct {
 		from       string
 		to         string
 		version    string
-		scopes     []string
+		scopes     map[string]struct{}
 		repository string
 		output     string
 		filename   string
@@ -142,7 +142,12 @@ func (a *action) getFlags(c *cli.Context) {
 	a.flags.from = c.String(fromFlag)
 	a.flags.to = c.String(toFlag)
 	a.flags.version = c.String(versionFlag)
-	a.flags.scopes = c.StringSlice(scopeFlag)
+
+	a.flags.scopes = make(map[string]struct{})
+	for _, scope := range c.StringSlice(scopeFlag) {
+		a.flags.scopes[scope] = struct{}{}
+	}
+
 	a.flags.repository = a.getFlagValue(c, repositoryFlag, defaultRepository)
 	a.flags.output = a.getFlagValue(c, outputFlag, defaultOutput)
 	a.flags.filename = a.getFlagValue(c, filenameFlag, defaultFilename)

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ const (
 	fromFlag       = "from"
 	toFlag         = "to"
 	versionFlag    = "version"
+	scopeFlag      = "scope"
 	repositoryFlag = "repository"
 	outputFlag     = "output"
 	filenameFlag   = "filename"
@@ -59,6 +60,10 @@ func main() {
 			&cli.StringFlag{
 				Name:  versionFlag,
 				Usage: "`VERSION` to generate, follow Semantic Versioning",
+			},
+			&cli.StringSliceFlag{
+				Name:  scopeFlag,
+				Usage: "scope to generate",
 			},
 			&cli.StringFlag{
 				Name:        repositoryFlag,
@@ -102,6 +107,7 @@ type action struct {
 		from       string
 		to         string
 		version    string
+		scopes     []string
 		repository string
 		output     string
 		filename   string
@@ -136,10 +142,15 @@ func (a *action) getFlags(c *cli.Context) {
 	a.flags.from = c.String(fromFlag)
 	a.flags.to = c.String(toFlag)
 	a.flags.version = c.String(versionFlag)
+	a.flags.scopes = c.StringSlice(scopeFlag)
 	a.flags.repository = a.getFlagValue(c, repositoryFlag, defaultRepository)
 	a.flags.output = a.getFlagValue(c, outputFlag, defaultOutput)
 	a.flags.filename = a.getFlagValue(c, filenameFlag, defaultFilename)
 	a.flags.filetype = a.getFlagValue(c, filetypeFlag, defaultFiletype)
+
+	if a.flags.debug {
+		a.logDebug("flags %+v", a.flags)
+	}
 }
 
 func (a *action) getFlagValue(c *cli.Context, flag, fallback string) string {

--- a/pkg/changelog/markdown.go
+++ b/pkg/changelog/markdown.go
@@ -70,6 +70,11 @@ func (g *MarkdownGenerator) getNewNodes(commits []convention.Commit, scopes map[
 	commitBases[othersType] = make([]markdown.Node, 0, defaultNodesLen)
 
 	for _, commit := range commits {
+		// Skip commit outside scopes
+		if _, ok := scopes[commit.Scope]; !ok {
+			continue
+		}
+
 		t := getType(commit.Type)
 		switch t {
 		case addedType:

--- a/pkg/changelog/markdown.go
+++ b/pkg/changelog/markdown.go
@@ -70,9 +70,12 @@ func (g *MarkdownGenerator) getNewNodes(commits []convention.Commit, scopes map[
 	commitBases[othersType] = make([]markdown.Node, 0, defaultNodesLen)
 
 	for _, commit := range commits {
-		// Skip commit outside scopes
-		if _, ok := scopes[commit.Scope]; !ok {
-			continue
+		// If scopes is empty or commit scope is empty, pass all commits
+		if len(scopes) != 0 && commit.Scope != "" {
+			// Skip commit outside scopes
+			if _, ok := scopes[commit.Scope]; !ok {
+				continue
+			}
 		}
 
 		t := getType(commit.Type)

--- a/pkg/changelog/markdown.go
+++ b/pkg/changelog/markdown.go
@@ -33,8 +33,8 @@ func NewMarkdownGenerator(oldData, version string, t time.Time) *MarkdownGenerat
 	}
 }
 
-func (g *MarkdownGenerator) Generate(commits []convention.Commit) string {
-	newBases := g.getNewNodes(commits)
+func (g *MarkdownGenerator) Generate(commits []convention.Commit, scopes map[string]struct{}) string {
+	newBases := g.getNewNodes(commits, scopes)
 	if len(newBases) == 0 {
 		return ""
 	}
@@ -57,7 +57,7 @@ func (g *MarkdownGenerator) Generate(commits []convention.Commit) string {
 	return markdown.Generate(nodes)
 }
 
-func (g *MarkdownGenerator) getNewNodes(commits []convention.Commit) []markdown.Node {
+func (g *MarkdownGenerator) getNewNodes(commits []convention.Commit, scopes map[string]struct{}) []markdown.Node {
 	if len(commits) == 0 {
 		return nil
 	}

--- a/pkg/changelog/markdown.go
+++ b/pkg/changelog/markdown.go
@@ -70,7 +70,7 @@ func (g *MarkdownGenerator) getNewNodes(commits []convention.Commit, scopes map[
 	commitBases[othersType] = make([]markdown.Node, 0, defaultNodesLen)
 
 	for _, commit := range commits {
-		t := getType(commit.GetType())
+		t := getType(commit.Type)
 		switch t {
 		case addedType:
 			commitBases[addedType] = append(commitBases[addedType], markdown.NewListItem(commit.String()))

--- a/pkg/changelog/markdown_test.go
+++ b/pkg/changelog/markdown_test.go
@@ -75,6 +75,48 @@ func TestMarkdownGeneratorGenerate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "ignore commits outside scope",
+			version: "v1.0.0",
+			t:       time.Date(2020, 3, 22, 0, 0, 0, 0, time.Local),
+			commits: []convention.Commit{
+				{
+					RawHeader: "feat: new feature",
+					Type:      convention.FeatType,
+				},
+				{
+					RawHeader: "feat(a): support new client",
+					Type:      convention.FeatType,
+					Scope:     "a",
+				},
+				{
+					RawHeader: "fix: new fix",
+					Type:      convention.FixType,
+				},
+				{
+					RawHeader: "fix(b): wrong color",
+					Type:      convention.FixType,
+					Scope:     "b",
+				},
+				{
+					RawHeader: "chore(a): new build",
+					Type:      convention.ChoreType,
+					Scope:     "a",
+				},
+				{
+					RawHeader: "chore(b): new build",
+					Type:      convention.ChoreType,
+					Scope:     "b",
+				},
+				{
+					RawHeader: "unleash the dragon",
+					Type:      convention.MiscType,
+				},
+			},
+			scopes: map[string]struct{}{
+				"a": struct{}{},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/changelog/markdown_test.go
+++ b/pkg/changelog/markdown_test.go
@@ -15,6 +15,7 @@ func TestMarkdownGeneratorGenerate(t *testing.T) {
 		version string
 		t       time.Time
 		commits []convention.Commit
+		scopes  map[string]struct{}
 	}{
 		{
 			name:    "empty old data",
@@ -80,7 +81,7 @@ func TestMarkdownGeneratorGenerate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := goldie.New(t)
 			markdownGenerator := NewMarkdownGenerator(tc.oldData, tc.version, tc.t)
-			got := markdownGenerator.Generate(tc.commits)
+			got := markdownGenerator.Generate(tc.commits, tc.scopes)
 			g.Assert(t, t.Name(), []byte(got))
 		})
 	}

--- a/pkg/changelog/testdata/TestMarkdownGeneratorGenerate/ignore_commits_outside_scope.golden
+++ b/pkg/changelog/testdata/TestMarkdownGeneratorGenerate/ignore_commits_outside_scope.golden
@@ -1,0 +1,19 @@
+# CHANGELOG
+
+## v1.0.0 (2020-3-22)
+
+### Added
+
+- feat: new feature
+
+- feat(a): support new client
+
+### Fixed
+
+- fix: new fix
+
+### Others
+
+- chore(a): new build
+
+- unleash the dragon

--- a/pkg/convention/commit.go
+++ b/pkg/convention/commit.go
@@ -16,8 +16,11 @@ import (
 var headerRegex = regexp.MustCompile(`(?P<type>[a-zA-Z]+)(?P<scope>\([a-zA-Z]+\))?(?P<attention>!)?:\s(?P<description>.+)`)
 
 type Commit struct {
+	// Commit as is
 	RawHeader string
-	Type      string
+
+	Type  string
+	Scope string
 }
 
 func NewCommit(c git.Commit) (result Commit, err error) {
@@ -50,4 +53,5 @@ func (c *Commit) UpdateType() {
 
 	headerSubmatches := headerRegex.FindStringSubmatch(c.RawHeader)
 	c.Type = strings.ToLower(headerSubmatches[1])
+	c.Scope = strings.ToLower(headerSubmatches[2])
 }

--- a/pkg/convention/commit.go
+++ b/pkg/convention/commit.go
@@ -13,7 +13,11 @@ import (
 // [optional body]
 // [optional footer(s)]
 
-var headerRegex = regexp.MustCompile(`(?P<type>[a-zA-Z]+)(?P<scope>\([a-zA-Z]+\))?(?P<attention>!)?:\s(?P<description>.+)`)
+var (
+	headerRegex = regexp.MustCompile(`(?P<type>[a-zA-Z]+)(?P<scope>\([a-zA-Z]+\))?(?P<attention>!)?:\s(?P<description>.+)`)
+
+	ErrEmptyCommit = errors.New("empty commit")
+)
 
 type Commit struct {
 	// Commit as is
@@ -24,30 +28,28 @@ type Commit struct {
 }
 
 func NewCommit(c git.Commit) (result Commit, err error) {
+	// Preprocess
 	message := strings.TrimSpace(c.Message)
 	messages := strings.Split(message, "\n")
 	if len(messages) == 0 {
-		err = errors.New("empty commit")
+		err = ErrEmptyCommit
 		return
 	}
 
+	// Use regex to detect
 	result.RawHeader = strings.TrimSpace(messages[0])
-	result.UpdateType()
+	if !headerRegex.MatchString(result.RawHeader) {
+		result.Type = MiscType
+		return
+	}
+
+	headerSubmatches := headerRegex.FindStringSubmatch(result.RawHeader)
+	result.Type = strings.ToLower(headerSubmatches[1])
+	result.Scope = strings.ToLower(headerSubmatches[2])
 
 	return
 }
 
 func (c *Commit) String() string {
 	return c.RawHeader
-}
-
-func (c *Commit) UpdateType() {
-	if !headerRegex.MatchString(c.RawHeader) {
-		c.Type = MiscType
-		return
-	}
-
-	headerSubmatches := headerRegex.FindStringSubmatch(c.RawHeader)
-	c.Type = strings.ToLower(headerSubmatches[1])
-	c.Scope = strings.ToLower(headerSubmatches[2])
 }

--- a/pkg/convention/commit.go
+++ b/pkg/convention/commit.go
@@ -37,10 +37,6 @@ func NewCommit(c git.Commit) (result Commit, err error) {
 	return
 }
 
-func (c *Commit) GetType() string {
-	return c.Type
-}
-
 func (c *Commit) String() string {
 	return c.RawHeader
 }

--- a/pkg/convention/commit.go
+++ b/pkg/convention/commit.go
@@ -46,6 +46,8 @@ func NewCommit(c git.Commit) (result Commit, err error) {
 	headerSubmatches := headerRegex.FindStringSubmatch(result.RawHeader)
 	result.Type = strings.ToLower(headerSubmatches[1])
 	result.Scope = strings.ToLower(headerSubmatches[2])
+	result.Scope = strings.TrimLeft(result.Scope, "(")
+	result.Scope = strings.TrimRight(result.Scope, ")")
 
 	return
 }

--- a/pkg/convention/testdata/TestNewCommit/Commit_message_with_no_body.golden
+++ b/pkg/convention/testdata/TestNewCommit/Commit_message_with_no_body.golden
@@ -1,4 +1,5 @@
 {
   "RawHeader": "docs: correct spelling of CHANGELOG",
-  "Type": "docs"
+  "Type": "docs",
+  "Scope": ""
 }

--- a/pkg/convention/testdata/TestNewCommit/Commit_message_with_not_character_to_draw_attention_to_breaking_change.golden
+++ b/pkg/convention/testdata/TestNewCommit/Commit_message_with_not_character_to_draw_attention_to_breaking_change.golden
@@ -1,4 +1,5 @@
 {
   "RawHeader": "refactor!: drop support for Node 6",
-  "Type": "refactor"
+  "Type": "refactor",
+  "Scope": ""
 }

--- a/pkg/convention/testdata/TestNewCommit/Commit_message_with_scope.golden
+++ b/pkg/convention/testdata/TestNewCommit/Commit_message_with_scope.golden
@@ -1,4 +1,5 @@
 {
   "RawHeader": "feat(lang): add polish language",
-  "Type": "feat"
+  "Type": "feat",
+  "Scope": "(lang)"
 }

--- a/pkg/convention/testdata/TestNewCommit/Commit_message_with_scope.golden
+++ b/pkg/convention/testdata/TestNewCommit/Commit_message_with_scope.golden
@@ -1,5 +1,5 @@
 {
   "RawHeader": "feat(lang): add polish language",
   "Type": "feat",
-  "Scope": "(lang)"
+  "Scope": "lang"
 }

--- a/pkg/convention/testdata/TestNewCommit/Misc.golden
+++ b/pkg/convention/testdata/TestNewCommit/Misc.golden
@@ -1,4 +1,5 @@
 {
   "RawHeader": "random git message",
-  "Type": "misc"
+  "Type": "misc",
+  "Scope": ""
 }

--- a/pkg/convention/testdata/TestNewCommit/Mixedcase.golden
+++ b/pkg/convention/testdata/TestNewCommit/Mixedcase.golden
@@ -1,4 +1,5 @@
 {
   "RawHeader": "Docs: correct spelling of CHANGELOG",
-  "Type": "docs"
+  "Type": "docs",
+  "Scope": ""
 }

--- a/pkg/convention/testdata/TestNewCommit/Uppercase.golden
+++ b/pkg/convention/testdata/TestNewCommit/Uppercase.golden
@@ -1,4 +1,5 @@
 {
   "RawHeader": "REFACTOR!: drop support for Node 6",
-  "Type": "refactor"
+  "Type": "refactor",
+  "Scope": ""
 }


### PR DESCRIPTION
Support filter for commit with scope: `feat(a): some change`.

Without flag `--scope`: all commits will be generated.

With flag `--scope`: only general commits (commit without scope) and commit with correct scope are generated.
