### PR TITLE
feat: require input version > current tag version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/haunt98/changeloguru
 go 1.24
 
 require (
-	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/go-git/go-git/v5 v5.14.0
+	github.com/hashicorp/go-version v1.7.0
 	github.com/make-go-great/color-go v0.5.0
 	github.com/make-go-great/date-go v0.5.0
 	github.com/make-go-great/ioe-go v0.4.0
@@ -14,7 +14,6 @@ require (
 	github.com/sebdah/goldie/v2 v2.5.5
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v3 v3.1.1
-	golang.org/x/mod v0.24.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
-github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
@@ -38,6 +36,8 @@ github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8J
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -100,8 +100,6 @@ golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
 golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
-golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
-golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.36.0 h1:vWF2fRbw4qslQsQzgFqZff+BItCvGFQqKzKIzx1rmoA=
 golang.org/x/net v0.36.0/go.mod h1:bFmbeoIPfrw4sMHNhb4J9f6+tPziuGjq7Jk/38fxi1I=

--- a/internal/changelog/generate.go
+++ b/internal/changelog/generate.go
@@ -7,6 +7,6 @@ import (
 	"github.com/make-go-great/date-go"
 )
 
-func generateVersionHeaderValue(version string, when time.Time) string {
-	return fmt.Sprintf("%s (%s)", version, date.FormatDateByDefault(when, time.Local))
+func generateVersionHeaderValue(ver string, when time.Time) string {
+	return fmt.Sprintf("%s (%s)", ver, date.FormatDateByDefault(when, time.Local))
 }

--- a/internal/changelog/markdown.go
+++ b/internal/changelog/markdown.go
@@ -15,7 +15,7 @@ const (
 	thirdLevel  = 3
 )
 
-func GenerateMarkdown(commits []convention.Commit, version string, when time.Time) []markdown.Node {
+func GenerateMarkdown(commits []convention.Commit, ver string, when time.Time) []markdown.Node {
 	filteredCommits := filter(commits)
 	if filteredCommits == nil {
 		return nil
@@ -41,7 +41,7 @@ func GenerateMarkdown(commits []convention.Commit, version string, when time.Tim
 	}
 
 	// Adding title
-	versionHeader := generateVersionHeaderValue(version, when)
+	versionHeader := generateVersionHeaderValue(ver, when)
 	nodes = append([]markdown.Node{
 		markdown.NewHeader(firstLevel, title),
 		markdown.NewHeader(secondLevel, versionHeader),

--- a/internal/changelog/markdown_test.go
+++ b/internal/changelog/markdown_test.go
@@ -15,7 +15,7 @@ func TestGenerateMarkdown(t *testing.T) {
 	tests := []struct {
 		name    string
 		commits []convention.Commit
-		version string
+		ver     string
 		when    time.Time
 	}{
 		{
@@ -34,8 +34,8 @@ func TestGenerateMarkdown(t *testing.T) {
 					Type:      convention.ChoreType,
 				},
 			},
-			version: "v1.0.0",
-			when:    time.Date(2020, 1, 18, 0, 0, 0, 0, time.Local),
+			ver:  "v1.0.0",
+			when: time.Date(2020, 1, 18, 0, 0, 0, 0, time.Local),
 		},
 		{
 			name: "many commits",
@@ -73,15 +73,15 @@ func TestGenerateMarkdown(t *testing.T) {
 					Type:      convention.MiscType,
 				},
 			},
-			version: "v1.0.0",
-			when:    time.Date(2020, 1, 18, 0, 0, 0, 0, time.Local),
+			ver:  "v1.0.0",
+			when: time.Date(2020, 1, 18, 0, 0, 0, 0, time.Local),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := goldie.New(t)
-			got := GenerateMarkdown(tc.commits, tc.version, tc.when)
+			got := GenerateMarkdown(tc.commits, tc.ver, tc.when)
 			g.Assert(t, t.Name(), []byte(markdown.GenerateText(got)))
 		})
 	}

--- a/internal/changelog/rst.go
+++ b/internal/changelog/rst.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GenerateRST base on GenerateMarkdown
-func GenerateRST(commits []convention.Commit, version string, when time.Time) []rst.Node {
+func GenerateRST(commits []convention.Commit, ver string, when time.Time) []rst.Node {
 	filteredCommits := filter(commits)
 	if filteredCommits == nil {
 		return nil
@@ -32,7 +32,7 @@ func GenerateRST(commits []convention.Commit, version string, when time.Time) []
 		}
 	}
 
-	versionHeader := generateVersionHeaderValue(version, when)
+	versionHeader := generateVersionHeaderValue(ver, when)
 	nodes = append([]rst.Node{
 		rst.NewTitle(title),
 		rst.NewSection(versionHeader),

--- a/internal/changelog/rst_test.go
+++ b/internal/changelog/rst_test.go
@@ -15,7 +15,7 @@ func TestGenerateRST(t *testing.T) {
 	tests := []struct {
 		name    string
 		commits []convention.Commit
-		version string
+		ver     string
 		when    time.Time
 	}{
 		{
@@ -34,8 +34,8 @@ func TestGenerateRST(t *testing.T) {
 					Type:      convention.ChoreType,
 				},
 			},
-			version: "v1.0.0",
-			when:    time.Date(2020, 1, 18, 0, 0, 0, 0, time.Local),
+			ver:  "v1.0.0",
+			when: time.Date(2020, 1, 18, 0, 0, 0, 0, time.Local),
 		},
 		{
 			name: "many commits",
@@ -73,15 +73,15 @@ func TestGenerateRST(t *testing.T) {
 					Type:      convention.MiscType,
 				},
 			},
-			version: "v1.0.0",
-			when:    time.Date(2020, 1, 18, 0, 0, 0, 0, time.Local),
+			ver:  "v1.0.0",
+			when: time.Date(2020, 1, 18, 0, 0, 0, 0, time.Local),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := goldie.New(t)
-			got := GenerateRST(tc.commits, tc.version, tc.when)
+			got := GenerateRST(tc.commits, tc.ver, tc.when)
 			g.Assert(t, t.Name(), []byte(rst.GenerateText(got)))
 		})
 	}

--- a/internal/git/models.go
+++ b/internal/git/models.go
@@ -1,8 +1,8 @@
 package git
 
 import (
-	"github.com/Masterminds/semver/v3"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/hashicorp/go-version"
 )
 
 // Commit stores all git-commit information
@@ -24,5 +24,5 @@ func newCommit(c *object.Commit) Commit {
 }
 
 type SemVerTag struct {
-	Version *semver.Version
+	Version *version.Version
 }


### PR DESCRIPTION
Close https://github.com/haunt98/changeloguru/issues/140

Also:
- Migrate from https://github.com/Masterminds/semver to https://github.com/hashicorp/go-version
- Remove useLatestTag
- Refactor `version string` to `ver string` to not collide with https://github.com/hashicorp/go-version